### PR TITLE
Extras page functionality

### DIFF
--- a/script.js
+++ b/script.js
@@ -147,7 +147,7 @@ let HTMLString =""
   HTMLString =HTMLString +`${h2(pageName, style1)}
 ${h3(contentTitle, style2)}`
 
-const buildSection =()=> {
+const buildSectionView =()=> {
 onlineDivHTML = ""
 for(let i=0; i<Array.length; i++){
 onlineDivHTML = onlineDivHTML +`${divExtras[i]()}`

--- a/script.js
+++ b/script.js
@@ -110,15 +110,8 @@ return `<ul id="list">${unorderedListBuild}</ul>`
 }
 
 
-
 // run below this to check functionality
 // document.querySelector("#career").innerHTML = createListComponent(linData.career.awards, "shortIntro")
-
-
-
-
-
-
 
 // Div container function for extras page
   const divExtras = (style, insideDivTitle, style1, url, altText, style2) => {
@@ -169,27 +162,36 @@ const h4 = (insideDivTitle, style) => {
   return `<h4 class="${style}">${insideDivTitle}</h4>`
 }
 
-
+//************************************************************************************************* */
 //call the functions to create extras page
 const buildExtrasPage = (section, pageName, style1, contentTitle, style2)=> {
 let HTMLString =""
   HTMLString =HTMLString +`${h2(pageName, style1)}
 ${h3(contentTitle, style2)}`
 
-const buildSectionView =()=> {
+//build a section for the online resources
+const buildSectionOnlineRes =()=> {
 onlineDivHTML = ""
 for(let i=0; i<Array.length; i++){
 onlineDivHTML = onlineDivHTML +`${divExtras[i]()}`
 }
 
+//build a section for the places to viwe
+const buildSectionPlacesToView =()=>{
 placesToViewHTML = ""
 for(let i=0; i<Array.length; i++){
 placesToViewHTML = placesToViewHTML+ `${divExtras[i]()}`
 }
 
+}
+
+//build a section for past show dates
+
+const buildSectionShowDates = ()=>{
 ${h3()}
 for (let i = 0; Array.length; i++){
 ${ul()}
+}
 }
 
    

--- a/script.js
+++ b/script.js
@@ -179,74 +179,6 @@ const finishedCareerPageHTML = careerPageHTML("Career", "Intro:", linData.career
 
 document.querySelector("#career").innerHTML = finishedCareerPageHTML
 
-//************************************************************************************************* */
-
-
-// start creating functions to make sections for extras page
-
-
-//build a section for online resources
-const buildSectionOnlineRes = (style, array)=>{
-  let buildString = ""
-  for(let i=0;i<array.length; i++){
-    
-   let HTMLString = divExtras(style, array[i].name, array[i].url, "Link")  
-   buildString = `${buildString}${HTMLString}`
-   console.log("this is the string it is building in online res", buildString)
-  }
-  //add header to string
-  buildString = `<h3>Online Resources</h3>${buildString}`
-  //return HTML string 
-  return buildString;
-  }
-  const onlineResourcesString = buildSectionOnlineRes("divStyle", linData.extrasReport.onlineResources)
-  console.log("online resources string", onlineResourcesString)
-  
-  // document.querySelector("#extras-report").innerHTML=buildSectionOnlineRes("divStyle", linData.extrasReport.onlineResources)
-  
-  //build a section for places to view
-  
-  const buildSectionPlacesToView = (style, array)=>{
-    let buildString = ""
-    for(let i=0;i<array.length; i++){
-      
-     let HTMLString = divExtras(style, array[i].name, array[i].url, "Link")  
-     buildString = buildString + HTMLString
-    }
-    buildString = `<h3>Places to View</h3> ${buildString}`
-    return buildString;
-    }
-    const placesToViewString = buildSectionPlacesToView("divStyle", linData.extrasReport.placesToViewWork)
-  
-    // document.querySelector("#extras-report").innerHTML=buildSectionPlacesToView("divStyle", linData.extrasReport.placesToViewWork)
-    
-  
-  
-  
-  // build a section for past show dates
-   
-  const buildSectionShowDates = (array, listClass) => {
-    let buildString = "";
-    buildString = buildString + createListComponent(array, listClass)
-    buildString = `<h3>Past Show Dates</h3> ${buildString}`
-  return buildString;
-  }
-    
- const showDatesString = buildSectionShowDates(linData.extrasReport.pastShowDates, "list")
- 
- document.querySelector("#extras-report").innerHTML = `${onlineResourcesString}${placesToViewString}${showDatesString}`
-
-// function for full list component
-// const createListComponent = (listInfo, listClass) => {
-//   let unorderedListBuild = ""
-
-//   for(let i=0; i < listInfo.length; i++){
-
-//    unorderedListBuild += li(listInfo[i], listClass)
-// }
-// return `<ul class="list">${unorderedListBuild}</ul>`
-
-
 
 
 const personalBuilder=(personalLife, birthDate, date, birthLocation, location, cityOfResidence, city, nationality, natLocs, family, spouseLable, spouse, parentsLable, parents, kidsLable, kids, petsLable, pets ) => `${h2(personalLife)}
@@ -271,6 +203,39 @@ ${createListComponent(pets)}
 
 document.querySelector("#personal-life").innerHTML = personalBuilder(
 "Personal Life", "Birth Date:", linData.personalLife.birthDate, "Birth Location:", linData.personalLife.birthLocation, "City of Residence:", linData.personalLife.cityOfResidence, "Nationality:", linData.personalLife.nationality, "Family:", "Spouse:", linData.personalLife.family.spouse, "Parents:", linData.personalLife.family.parents, "Kids:", linData.personalLife.family.kids, "Pets:", linData.personalLife.family.pets)
+
+//**************************************************************************************************/
+// start creating functions to make sections for extras page
+//build a function that can make section for online resources and Places to View
+
+const buildSectionExtras = (style, array, header, sectionClass)=>{
+  let buildString = ""
+  for(let i=0;i<array.length; i++){
+    // call and loop through divExtras function
+   let HTMLString = divExtras(style, array[i].name, array[i].url, "Link")  
+   buildString = `${buildString}${HTMLString}`
+  //  console.log("this is the string it is building in online res", buildString)
+  }
+  //add header to string
+  buildString = `${h3(header)}<section class =${sectionClass}>${buildString}</section>`
+  //return HTML string 
+  return buildString;
+  }
+  const onlineResourcesString = buildSectionExtras("divStyle", linData.extrasReport.onlineResources, "Online Resources", "extras-section")
+  const placesToViewString = buildSectionExtras("divStyle", linData.extrasReport.placesToViewWork, "Places to View", "extras-section")
+  // console.log("online resources string", onlineResourcesString) 
+  
+  // build a section for past show dates   
+  const buildSectionShowDates = (array, listClass) => {
+    let buildString = "";
+    buildString = buildString + createListComponent(array, listClass)
+    buildString = `<h3>Past Show Dates</h3> ${buildString}`
+  return buildString;
+  }
+    
+ const showDatesString = buildSectionShowDates(linData.extrasReport.pastShowDates, "list")
+ 
+ document.querySelector("#extras-report").innerHTML = `${h2("Extras")}${onlineResourcesString}${placesToViewString}${showDatesString}`
 
 
 

--- a/script.js
+++ b/script.js
@@ -164,10 +164,10 @@ const h4 = (insideDivTitle, style) => {
 
 //************************************************************************************************* */
 //call the functions to create extras page
-const buildExtrasPage = (section, pageName, style1, contentTitle, style2)=> {
+const buildExtrasPage = (pageName, contentTitle)=> {
 let HTMLString =""
-  HTMLString =HTMLString +`${h2(pageName, style1)}
-${h3(contentTitle, style2)}`
+  HTMLString =HTMLString +`${h2(pageName)}
+${h3(contentTitle)}`
 
 //build a section for the online resources
 const buildSectionOnlineRes =()=> {

--- a/script.js
+++ b/script.js
@@ -129,7 +129,7 @@ const divNews = (style, insideDivTitle, url, altText, text) => {
     </div>`
 }
 //link-functions
-const links = (url, altText) => {
+const a = (url, altText) => {
   return `<a href=${url} target="_blank">${altText}</a>`
 }
 //How to call the function (insert your section into ("#sectionName"):
@@ -161,25 +161,46 @@ const h4 = (insideDivTitle) => {
 //************************************************************************************************* */
 
 
-//build a section for the online resources
-const buildSectionOnlineRes =(insideDivTitle, url, altText)=> {
-onlineDivHTML = ""
-for(let i=0; i<Array.length; i++){
-onlineDivHTML = onlineDivHTML +`${divExtras[i](insideDivTitle, url, altText)}`
+// start creating functions to make sections for extras page
+
+
+//build a section for online resources
+const buildSectionOnlineRes = (style, array)=>{
+let buildString = ""
+for(let i=0;i<array.length; i++){
+  
+ let HTMLString = divExtras(style, array[i].name, array[i].url, "Link")  
+ buildString = buildString + HTMLString
 }
+//add header to string
+buildString = `<h3>Online Resources</h3>${buildString}`
+//return HTML string 
+return buildString;
+}
+const onlineResourcesString = buildSectionOnlineRes("divStyle", linData.extrasReport.onlineResources)
 
-document.querySelector("#extras-report").innerHTML=buildSectionOnlineRes(linData.extrasReport.onlineResources.name, linData.extrasReport.onlineResources.url, "" )
+// document.querySelector("#extras-report").innerHTML=buildSectionOnlineRes("divStyle", linData.extrasReport.onlineResources)
 
-//build a section for the places to viwe
-// const buildSectionPlacesToView =()=>{
-// placesToViewHTML = ""
-// for(let i=0; i<Array.length; i++){
-// placesToViewHTML = placesToViewHTML+ `${divExtras[i]()}`
-// }
+//build a section for places to view
 
-// }
+const buildSectionPlacesToView = (style, array)=>{
+  let buildString = ""
+  for(let i=0;i<array.length; i++){
+    
+   let HTMLString = divExtras(style, array[i].name, array[i].url, "Link")  
+   buildString = buildString + HTMLString
+  }
+  buildString = `<h3>Places to View</h3> ${buildString}`
+  return buildString;
+  }
+  const placesToViewString = buildSectionPlacesToView("divStyle", linData.extrasReport.placesToViewWork)
 
-// //build a section for past show dates
+  document.querySelector("#extras-report").innerHTML=buildSectionPlacesToView("divStyle", linData.extrasReport.placesToViewWork)
+  document.querySelector("#extras-report").innerHTML = `${onlineResourcesString}${placesToViewString}`
+
+
+
+// build a section for past show dates
 
 // const buildSectionShowDates = ()=>{
 // ${h3()}

--- a/script.js
+++ b/script.js
@@ -98,14 +98,11 @@ const links = (url, altText, style) => {
 //How to call the function (insert your section into ("#sectionName"):
 //document.querySelector("#personal-life").innerHTML = links("https://en.wikipedia.org/wiki/Puerto_Rican_citizenship","PR citizenship", "green-background");
 
-
-
-  // This function creates a paragraph element with text and a user-defined style
+// This function creates a paragraph element with text and a user-defined style
   const P = (text, style) => {
     return `<p class="${style}">${text}</p>`
 }
   
-
 //H-elements
 const h1 = (title, style) => {
   return `<h1 class="${style}">${title}</h1>`
@@ -128,29 +125,30 @@ const h4 = (insideDivTitle, style) => {
 
 
 //call the functions to create extras page
-const extras = (section, pageName, style1, contentTitle, style2)=> {
-<section id ="">
-  return `${h2(pageName, style1)}
-${h3(contentTitle, style2)}
+const buildExtrasPage = (section, pageName, style1, contentTitle, style2)=> {
+let HTMLString =""
+  HTMLString =HTMLString +`${h2(pageName, style1)}
+${h3(contentTitle, style2)}`
+
+const buildSection =()=> {
+onlineDivHTML = ""
 for(let i=0; i<Array.length; i++){
-${divExtras()}
-${h3}(contentTitle, style2)
-for(let i=0)
-${divExtras()}
-${divExtras()}
+onlineDivHTML = onlineDivHTML +`${divExtras[i]()}`
+}
+
+placesToViewHTML = ""
+for(let i=0; i<Array.length; i++){
+placesToViewHTML = placesToViewHTML+ `${divExtras[i]()}`
+}
+
 ${h3()}
+for (let i = 0; Array.length; i++){
 ${ul()}
-
-   ``
 }
 
-  const createStudentComponent = (name, studentClass, sectionClass, info) => `
-    <div id="student">
-        ${h1(name, studentClass, "xx-large")}
-        ${section(sectionClass, "section--padded")}
-        ${aside(info, "pushRight")}
-    </div>
+   
 }
+
 
 
 

--- a/script.js
+++ b/script.js
@@ -118,3 +118,4 @@ const h4 = (insideDivTitle, style) => {
   return `<h4 class="${style}">${insideDivTitle}</h4>`
 }
 
+

--- a/script.js
+++ b/script.js
@@ -119,3 +119,30 @@ const h4 = (insideDivTitle, style) => {
 }
 
 
+//call the functions to create extras page
+const extras = (section, pageName, style1, contentTitle, style2)=> {
+<section id ="">
+  return `${h2(pageName, style1)}
+${h3(contentTitle, style2)}
+for(let i=0; i<Array.length; i++){
+${divExtras()}
+${h3}(contentTitle, style2)
+for(let i=0)
+${divExtras()}
+${divExtras()}
+${h3()}
+${ul()}
+
+   ``
+}
+
+  const createStudentComponent = (name, studentClass, sectionClass, info) => `
+    <div id="student">
+        ${h1(name, studentClass, "xx-large")}
+        ${section(sectionClass, "section--padded")}
+        ${aside(info, "pushRight")}
+    </div>
+}
+
+
+

--- a/style.css
+++ b/style.css
@@ -3,10 +3,22 @@
     border: 2px solid black;
 }
 
-.divStyle{
+.extras-section{
+    width: 50vw;
     display: flex;
     flex-direction:row;
     align-items: center;
+    justify-content: space-around;
+    border: red solid 1px;
+
+}
+.divStyle{
+    display: flex;
+    flex-direction:column;
+    align-items: center;
+    justify-content: center;
+    margin: auto;
     color: red;
     border: black solid 1px;
 }
+

--- a/style.css
+++ b/style.css
@@ -2,3 +2,7 @@
     background-color: green;
     border: 2px solid black;
 }
+
+.divStyle{
+    color: red
+}


### PR DESCRIPTION
I edited and compiled the functions to print to the DOM for the extras section.  I had to change the text on the divExtras and divNews functions to remove the section tags (\<div class ="style"> instead of \<section div="style> so they would display properly in the DOM

What you should see:
in the DOM, \<h2> header with "Extras"

Section with \<h3> header for online resources (below which are three boxes with links to wikipedia, official website and fan website.  
section with \<h3> header for Places to View with two boxes below containing links to Youtube and Broadway (links are currently empty, nothing was in the object file)
Sections (flex containers) are bordered in red and divs (flex items) are bordered in black
Finally, you will see a bulleted list with an \<h3> header for Past Show dates.  List has 8 items (Jan 15, 2019 to Jun 18, 2018)

Try clicking on the links in the header--they pop down to the appropriate sections!